### PR TITLE
Fixed shortcut

### DIFF
--- a/secret/console-open-the-console-from-any-tab.md
+++ b/secret/console-open-the-console-from-any-tab.md
@@ -19,4 +19,4 @@ tags:
 
 <p class="safari">In Safari, the console sits at the bottom of the developer tools. The escape key is used to toggle visibility of the console log. Executing a command in to the console command line will also open the console log.</p>
 
-<p class="firefox">In Firefox, you can quickly navigate to the console by pressing either Ctrl, Shift and K on Windows or Cmd ⌘, Shift and K on Mac.</p>
+<p class="firefox">In Firefox, you can quickly navigate to the console by pressing either Ctrl, Shift and K on Windows or Cmd ⌘, Option ⌥ and K on Mac.</p>


### PR DESCRIPTION
I've fixed the console shortcut for Firefox on Mac. It's actually Cmd ⌘, Option ⌥ and K, not Cmd ⌘, Shift and K.

Thanks for putting together these fantastic docs!
