### PR TITLE
Firefox extension to override geolocation

### DIFF
--- a/secret/extensions-override-geolocation.md
+++ b/secret/extensions-override-geolocation.md
@@ -1,0 +1,19 @@
+---
+date: 2013-06-23 7:06:05
+layout: secret
+published: true
+
+title: Override Geolocation
+authors:
+- Thomas Gratier # Your name.
+order: 99-99999
+browsers:
+- firefox
+parent: Extensions # must be one of the categories above
+categories:
+- Extensions # can be multiple
+tags:
+- secret # do not remove
+---
+<p>In Firefox, the API location can be overidden like in Chrome. In this case, you have to rely on the Geolocater addon. Install it from the <a href="https://addons.mozilla.org/fr/firefox/addon/geolocater/">official Mozilla addon website</a>.</p>
+<p>After installation, go to "Tools" menu, "Geolocater", "Manage". From here, you will be able to directly add a "fake" geolocation by browsing a map or searching place. After, you will be able to override geolocation and switch between predefined geolocations. You can confirm the behaviour, going to the <a href="http://html5demos.com/geo">html5demos for Geolocation</a> </p>


### PR DESCRIPTION
The default built-in override Geolocation from Chrome can be replace in Firefox with Geolocater addon.
I've added the secret in "Extensions". If you accept it, a reference from the Debugging > Override Geolocation require a link to this tip.
