### PR TITLE
Fixed missing column in 2nd console.table example.

### DIFF
--- a/secret/console-output-data-as-a-table.md
+++ b/secret/console-output-data-as-a-table.md
@@ -27,7 +27,7 @@ tags:
 
 <p>To give the table custom column names, property names must be assigned to the elements in the object. Likewise, custom values for the <code>(index)</code> column can be set by naming each set of properties.</p>
 
-<p>There is an optional second argument which allows you to explicity specify which columns to output. <code>console.table({"London":{population:8173194, country:"UK", elevation:"24m"},"New York":{population:8336697, country:"USA", elevation:"10m"}},["population", "country"])</code> will output the following.</p>
+<p>There is an optional second argument which allows you to explicity specify which columns to output. <code>console.table({"London":{population:8173194, country:"UK", elevation:"24m"},"New York":{population:8336697, country:"USA", elevation:"10m"}},["population", "country", "elevation"])</code> will output the following.</p>
 
 <div class="chrome image"><img src="/assets/img/placeholder.gif" data-src="/assets/img/secrets/chrome-table-custom-headings.png" /></div>
 


### PR DESCRIPTION
The example code was missing a column.
